### PR TITLE
Log Backward Compatability

### DIFF
--- a/Sources/CombustionBLE/UART/LogResponse.swift
+++ b/Sources/CombustionBLE/UART/LogResponse.swift
@@ -33,7 +33,7 @@ class LogResponse: Response {
     let sequenceNumber: UInt32
     let temperatures: ProbeTemperatures
     
-    init(data: Data, success: Bool) {
+    init(data: Data, success: Bool, payloadLength: Int) {
         let sequenceByteIndex = Response.HEADER_LENGTH
         let sequenceRaw = data.subdata(in: sequenceByteIndex..<(sequenceByteIndex + 4))
         sequenceNumber = sequenceRaw.withUnsafeBytes {
@@ -47,6 +47,17 @@ class LogResponse: Response {
         // print("******** Received response!")
         // print("Sequence = \(sequenceNumber) : Temperature = \(temperatures)")
 
-        super.init(success: success, payLoadLength: LogResponse.PAYLOAD_LENGTH)
+        super.init(success: success, payLoadLength: payloadLength)
+    }
+}
+
+extension LogResponse {
+
+    static func fromRaw(data: Data, success: Bool, payloadLength: Int) -> LogResponse? {
+        if(payloadLength < PAYLOAD_LENGTH) {
+            return nil
+        }
+            
+        return LogResponse(data: data, success: success, payloadLength: payloadLength)
     }
 }

--- a/Sources/CombustionBLE/UART/Response.swift
+++ b/Sources/CombustionBLE/UART/Response.swift
@@ -119,13 +119,13 @@ extension Response {
         
         switch messageType {
         case .Log:
-            return LogResponse(data: data, success: success)
+            return LogResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
         case .SetID:
             return SetIDResponse(success: success, payLoadLength: Int(payloadLength))
         case .SetColor:
             return SetColorResponse(success: success, payLoadLength: Int(payloadLength))
         case .SessionInfo:
-            return SessionInfoResponse(data: data, success: success)
+            return SessionInfoResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
         }
     }
 }

--- a/Sources/CombustionBLE/UART/SessionInfo.swift
+++ b/Sources/CombustionBLE/UART/SessionInfo.swift
@@ -42,7 +42,7 @@ class SessionInfoResponse: Response {
     
     let info: SessionInformation
     
-    init(data: Data, success: Bool) {
+    init(data: Data, success: Bool, payloadLength: Int) {
         let sequenceByteIndex = Response.HEADER_LENGTH
         let sessionIDRaw = data.subdata(in: sequenceByteIndex..<(sequenceByteIndex + 4))
         let sessionID = sessionIDRaw.withUnsafeBytes {
@@ -56,6 +56,17 @@ class SessionInfoResponse: Response {
         
         info = SessionInformation(sessionID: sessionID, samplePeriod: samplePeriod)
 
-        super.init(success: success, payLoadLength: SessionInfoResponse.PAYLOAD_LENGTH)
+        super.init(success: success, payLoadLength: payloadLength)
+    }
+}
+
+extension SessionInfoResponse {
+
+    static func fromRaw(data: Data, success: Bool, payloadLength: Int) -> SessionInfoResponse? {
+        if(payloadLength < PAYLOAD_LENGTH) {
+            return nil
+        }
+            
+        return SessionInfoResponse(data: data, success: success, payloadLength: payloadLength)
     }
 }


### PR DESCRIPTION
- Support log message backwards compatibility (e.g. message from `v0.8.2` probe firmware).