### PR TITLE
Feature/ios 74 add meatnet set prediction support

### DIFF
--- a/Sources/CombustionBLE/BleManager.swift
+++ b/Sources/CombustionBLE/BleManager.swift
@@ -92,6 +92,13 @@ class BleManager : NSObject {
         }
     }
     
+    func sendRequest(identifier: String, request: NodeRequest) {
+        if let connectionPeripheral = getConnectedPeripheral(identifier: identifier),
+            let uartChar = uartCharacteristics[identifier] {
+            connectionPeripheral.writeValue(request.data, for: uartChar, type: .withoutResponse)
+        }
+    }
+    
     func startFirmwareUpdate(device: Device, dfu: DFUFirmware) -> DFUServiceController? {
         guard let bleIdentifier = device.bleIdentifier, let connectedPeripheral = getConnectedPeripheral(identifier: bleIdentifier) else { return nil }
         

--- a/Sources/CombustionBLE/Device.swift
+++ b/Sources/CombustionBLE/Device.swift
@@ -90,7 +90,7 @@ public class Device : ObservableObject {
     }
     
     /// Minimum possible value for RSSI
-    private let MIN_RSSI = -128
+    static internal let MIN_RSSI = -128
     
     
     /// DFU Upload progress
@@ -111,7 +111,7 @@ public class Device : ObservableObject {
         if let RSSI = RSSI {
             self.rssi = RSSI.intValue
         } else {
-            self.rssi = MIN_RSSI
+            self.rssi = Device.MIN_RSSI
         }
     }
     

--- a/Sources/CombustionBLE/DeviceManager.swift
+++ b/Sources/CombustionBLE/DeviceManager.swift
@@ -40,7 +40,7 @@ public class DeviceManager : ObservableObject {
     
     public enum Constants {
         public static let MINIMUM_PREDICTION_SETPOINT_CELSIUS = 0.0
-        public static let MAXIMUM_PREDICTION_SETPOINT_CELSIUS = 102.0
+        public static let MAXIMUM_PREDICTION_SETPOINT_CELSIUS = 100.0
     }
     
     /// Dictionary of discovered devices.
@@ -138,6 +138,39 @@ public class DeviceManager : ObservableObject {
         return getDevices().max{ $0.rssi < $1.rssi }
     }
     
+    /// Gets the best Node for communicating with a Probe.
+    func getBestNodeForProbe(serialNumber: UInt32) -> MeatNetNode? {
+        var foundNode : MeatNetNode? = nil
+        // Check Nodes to which we are connected to see if they have a route to the Probe
+        for (_, device) in devices {
+            if let node = device as? MeatNetNode {
+                // Check multiple Nodes and choose the one with the best RSSI to this device.
+                var foundRssi = Device.MIN_RSSI
+                if let _ = node.getNetworkedProbe(serialNumber: serialNumber) {
+                    if node.rssi > foundRssi {
+                        foundNode = node
+                        foundRssi = node.rssi
+                    }
+                }
+            }
+        }
+        return foundNode
+    }
+    
+    /// Returns the best device to which to send a request to a Probe, if there is one.
+    public func getBestRouteToProbe(serialNumber: UInt32) -> Device? {
+        var foundDevice : Device? = nil
+        
+        if let probe = findProbeBySerialNumber(serialNumber: serialNumber), probe.connectionState == .connected {
+            // If we're directly connected to this probe, send the request directly.
+            foundDevice = probe
+        } else {
+            foundDevice = getBestNodeForProbe(serialNumber: serialNumber)
+        }
+        
+        return foundDevice
+    }
+    
     func connectToDevice(_ device: Device) {
         if let _ = device as? SimulatedProbe, let bleIdentifier = device.bleIdentifier, let uuid = UUID(uuidString: bleIdentifier) {
             // If this device is a Simulated Probe, use a simulated connection.
@@ -227,15 +260,34 @@ public class DeviceManager : ObservableObject {
             completionHandler(false)
             return
         }
-        // TODO - Send request via Node.
         
-        if let device = device as? Probe, let bleIdentifier = device.bleIdentifier {
-            // Store completion handler
-            messageHandlers.addSetPredictionCompletionHandler(device, completionHandler: completionHandler)
+        if let device = device as? Probe {
             
-            // Send request to device
-            let request = SetPredictionRequest(setPointCelsius: removalTemperatureC, mode: .timeToRemoval)
-            BleManager.shared.sendRequest(identifier: bleIdentifier, request: request)
+            let targetDevice = getBestRouteToProbe(serialNumber: device.serialNumber)
+            
+            if let probe = targetDevice as? Probe, let bleIdentifier = probe.bleIdentifier {
+                // If the best route is directly to the Probe, send it that way.
+             
+                // Store completion handler
+                messageHandlers.addSetPredictionCompletionHandler(device, completionHandler: completionHandler)
+                
+                // Send request to device
+                let request = SetPredictionRequest(setPointCelsius: removalTemperatureC, mode: .timeToRemoval)
+                BleManager.shared.sendRequest(identifier: bleIdentifier, request: request)
+                
+            } else if let node = targetDevice as? MeatNetNode, let bleIdentifier = node.bleIdentifier {
+                // If the best route is through a Node, send it that way.
+                
+                // Store completion handler
+                messageHandlers.addNodeSetPredictionCompletionHandler(node, completionHandler: completionHandler)
+                
+                // Send request to device
+                let request = NodeSetPredictionRequest(serialNumber: device.serialNumber,
+                                                       setPointCelsius: removalTemperatureC,
+                                                       mode: .timeToRemoval)
+                BleManager.shared.sendRequest(identifier: bleIdentifier, request: request)
+            }
+           
         }
     }
     
@@ -245,15 +297,34 @@ public class DeviceManager : ObservableObject {
     /// - parameter device: Device to cancel prediction on
     /// - parameter completionHandler: Completion handler to be called operation is complete
     public func cancelPrediction(_ device: Device, completionHandler: @escaping MessageHandlers.SuccessCompletionHandler) {
-        // TODO - Send request via Node.
         
-        if let device = device as? Probe, let bleIdentifier = device.bleIdentifier {
-            // Store completion handler
-            messageHandlers.addSetPredictionCompletionHandler(device, completionHandler: completionHandler)
+        if let device = device as? Probe {
             
-            // Send request to device
-            let request = SetPredictionRequest(setPointCelsius: 0.0, mode: .none)
-            BleManager.shared.sendRequest(identifier: bleIdentifier, request: request)
+            let targetDevice = getBestRouteToProbe(serialNumber: device.serialNumber)
+            
+            if let probe = targetDevice as? Probe, let bleIdentifier = probe.bleIdentifier {
+                // If the best route is directly to the Probe, send it that way.
+             
+                // Store completion handler
+                messageHandlers.addSetPredictionCompletionHandler(device, completionHandler: completionHandler)
+                
+                // Send request to device
+                let request = SetPredictionRequest(setPointCelsius: 0.0, mode: .none)
+                BleManager.shared.sendRequest(identifier: bleIdentifier, request: request)
+                
+            } else if let node = targetDevice as? MeatNetNode, let bleIdentifier = node.bleIdentifier {
+                // If the best route is through a Node, send it that way.
+                
+                // Store completion handler
+                messageHandlers.addNodeSetPredictionCompletionHandler(node, completionHandler: completionHandler)
+                
+                // Send request to device
+                let request = NodeSetPredictionRequest(serialNumber: device.serialNumber,
+                                                       setPointCelsius: 0.0,
+                                                       mode: .none)
+                BleManager.shared.sendRequest(identifier: bleIdentifier, request: request)
+            }
+           
         }
     }
     
@@ -317,7 +388,7 @@ extension DeviceManager : BleManagerDelegate {
     }
     
     func updateDeviceWithNodeStatus(serialNumber: UInt32, status: ProbeStatus, hopCount: HopCount) {
-        guard let probe = devices[String(serialNumber)] as? Probe else { return }
+        guard let probe = findProbeBySerialNumber(serialNumber: serialNumber) else { return }
         probe.updateProbeStatus(deviceStatus: status, hopCount: hopCount)
     }
     
@@ -412,6 +483,17 @@ extension DeviceManager : BleManagerDelegate {
         }
         
         return foundDevice
+    }
+    
+    func findProbeBySerialNumber(serialNumber: UInt32) -> Probe? {
+        var foundProbe : Probe? = nil
+        
+        if let probe = devices[String(serialNumber)] as? Probe {
+            // Probes are stored using their serial number encoded as a String as their key.
+            foundProbe = probe
+        }
+        
+        return foundProbe
     }
     
     func updateDeviceFwVersion(identifier: UUID, fwVersion: String) {
@@ -513,6 +595,11 @@ extension DeviceManager : BleManagerDelegate {
     
     func handleNodeUARTResponse(identifier: UUID, response: NodeResponse) {
         print("Received Response from Node: \(response)")
+        
+        if let setPredictionResponse = response as? NodeSetPredictionResponse {
+            messageHandlers.callNodeSetPredictionCompletionHandler(identifier, response: setPredictionResponse)
+        }
+        
         /*
         if let logResponse = response as? LogResponse {
             updateDeviceWithLogResponse(identifier: identifier, logResponse: logResponse)
@@ -544,29 +631,14 @@ extension DeviceManager : BleManagerDelegate {
             updateDeviceWithNodeStatus(serialNumber: statusRequest.serialNumber,
                                        status: probeStatus,
                                        hopCount: hopCount)
-        }
-        
-        /*
-        if let logResponse = response as? LogResponse {
-            updateDeviceWithLogResponse(identifier: identifier, logResponse: logResponse)
-        }
-        else if let setIDResponse = response as? SetIDResponse {
-            messageHandlers.callSetIDCompletionHandler(identifier, response: setIDResponse)
-        }
-        else if let setColorResponse = response as? SetColorResponse {
-            messageHandlers.callSetColorCompletionHandler(identifier, response: setColorResponse)
-        }
-        else if let sessionResponse = response as? SessionInfoResponse {
-            if(sessionResponse.success) {
-                updateDeviceWithSessionInformation(identifier: identifier, sessionInformation: sessionResponse.info)
+            
+            // Ensure the Node that sent this item has the Probe in its list of repeated devices.
+            if let node = findDeviceByBleIdentifier(bleIdentifier: identifier) as? MeatNetNode,
+               let probe = findProbeBySerialNumber(serialNumber: statusRequest.serialNumber) {
+                // Add the probe to the node's list of networked probes
+                node.updateNetworkedProbe(probe: probe)
             }
         }
-        else if let setPredictionResponse = response as? SetPredictionResponse {
-            messageHandlers.callSetPredictionCompletionHandler(identifier, response: setPredictionResponse)
-        }
-        else if let readOverTemperatureResponse = response as? ReadOverTemperatureResponse {
-            messageHandlers.callReadOverTemperatureCompletionHandler(identifier, response: readOverTemperatureResponse)
-        }
-        */
     }
+    
 }

--- a/Sources/CombustionBLE/DeviceManager.swift
+++ b/Sources/CombustionBLE/DeviceManager.swift
@@ -599,29 +599,6 @@ extension DeviceManager : BleManagerDelegate {
         if let setPredictionResponse = response as? NodeSetPredictionResponse {
             messageHandlers.callNodeSetPredictionCompletionHandler(identifier, response: setPredictionResponse)
         }
-        
-        /*
-        if let logResponse = response as? LogResponse {
-            updateDeviceWithLogResponse(identifier: identifier, logResponse: logResponse)
-        }
-        else if let setIDResponse = response as? SetIDResponse {
-            messageHandlers.callSetIDCompletionHandler(identifier, response: setIDResponse)
-        }
-        else if let setColorResponse = response as? SetColorResponse {
-            messageHandlers.callSetColorCompletionHandler(identifier, response: setColorResponse)
-        }
-        else if let sessionResponse = response as? SessionInfoResponse {
-            if(sessionResponse.success) {
-                updateDeviceWithSessionInformation(identifier: identifier, sessionInformation: sessionResponse.info)
-            }
-        }
-        else if let setPredictionResponse = response as? SetPredictionResponse {
-            messageHandlers.callSetPredictionCompletionHandler(identifier, response: setPredictionResponse)
-        }
-        else if let readOverTemperatureResponse = response as? ReadOverTemperatureResponse {
-            messageHandlers.callReadOverTemperatureCompletionHandler(identifier, response: readOverTemperatureResponse)
-        }
-        */
     }
     
     func handleNodeUARTRequest(identifier: UUID, request: NodeRequest) {

--- a/Sources/CombustionBLE/MeatNetNode.swift
+++ b/Sources/CombustionBLE/MeatNetNode.swift
@@ -54,6 +54,11 @@ public class MeatNetNode: Device {
     func updateNetworkedProbe(probe : Probe) {
         probes[probe.serialNumber] = probe
     }
+    
+    /// Returns probe associated with the specified serial number, if it's in this list.
+    func getNetworkedProbe(serialNumber: UInt32) -> Probe? {
+        return probes[serialNumber]
+    }
 
 
 }

--- a/Sources/CombustionBLE/MessageHandlers.swift
+++ b/Sources/CombustionBLE/MessageHandlers.swift
@@ -52,11 +52,16 @@ public class MessageHandlers {
     private var setPredictionCompletionHandlers : [String: MessageSentHandler] = [:]
     private var readOverTemperatureCompletionHandlers : [String: MessageSentHandler] = [:]
     
+    // Node handlers
+    private var setNodePredictionCompletionHandlers : [String: MessageSentHandler] = [:]
+    
     func checkForTimeout() {
         checkForMessageTimeout(messageHandlers: &setIDCompletionHandlers)
         checkForMessageTimeout(messageHandlers: &setColorCompletionHandlers)
         checkForMessageTimeout(messageHandlers: &setPredictionCompletionHandlers)
         checkForMessageTimeout(messageHandlers: &readOverTemperatureCompletionHandlers)
+        
+        checkForMessageTimeout(messageHandlers: &setNodePredictionCompletionHandlers)
     }
     
     func clearHandlersForDevice(_ identifier: UUID) {
@@ -64,6 +69,8 @@ public class MessageHandlers {
         setIDCompletionHandlers.removeValue(forKey: identifier.uuidString)
         setPredictionCompletionHandlers.removeValue(forKey: identifier.uuidString)
         readOverTemperatureCompletionHandlers.removeValue(forKey: identifier.uuidString)
+        
+        setNodePredictionCompletionHandlers.removeValue(forKey: identifier.uuidString)
     }
     
     func addSetIDCompletionHandler(_ device: Device, completionHandler: @escaping SuccessCompletionHandler) {
@@ -147,5 +154,25 @@ public class MessageHandlers {
     private func callSuccessCompletionHandler(identifier: UUID, success: Bool, handlers: inout [String: MessageSentHandler]) {
         handlers[identifier.uuidString]?.successHandler?(success)
         handlers.removeValue(forKey: identifier.uuidString)
+    }
+}
+
+///////////////////////////////////
+/// MARK - MeatNet Node completion handlers
+///////////////////////////////////
+
+extension MessageHandlers {
+    func addNodeSetPredictionCompletionHandler(_ device: Device, completionHandler: @escaping SuccessCompletionHandler) {
+        if let bleIdentifier = device.bleIdentifier {
+            setNodePredictionCompletionHandlers[bleIdentifier] = MessageSentHandler(timeSent: Date(),
+                                                                                    successHandler: completionHandler,
+                                                                                    readOverTemperatureHandler: nil)
+        }
+    }
+    
+    func callNodeSetPredictionCompletionHandler(_ identifier: UUID, response: NodeSetPredictionResponse) {
+        callSuccessCompletionHandler(identifier: identifier,
+                                     success: response.success,
+                                     handlers: &setNodePredictionCompletionHandlers)
     }
 }

--- a/Sources/CombustionBLE/UART/MeatNet/NodeProbeStatusRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeProbeStatusRequest.swift
@@ -42,12 +42,12 @@ class NodeProbeStatusRequest: NodeRequest {
         }
         
         // Parse Probe Status
-        let probeStatusRaw = data.subdata(in: (sequenceByteIndex + 4)..<(sequenceByteIndex + 31))
+        let probeStatusRaw = data.subdata(in: (sequenceByteIndex + 4)..<(sequenceByteIndex + 34))
         if let ps = ProbeStatus(fromData: probeStatusRaw) {
             self.probeStatus = ps
         }
         
-        let hopCountRaw = data.subdata(in: (sequenceByteIndex + 31)..<(sequenceByteIndex + 32))
+        let hopCountRaw = data.subdata(in: (sequenceByteIndex + 34)..<(sequenceByteIndex + 35))
         let hopCountInteger = hopCountRaw.withUnsafeBytes {
             $0.load(as: UInt8.self)
         }

--- a/Sources/CombustionBLE/UART/MeatNet/NodeResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeResponse.swift
@@ -69,7 +69,7 @@ extension NodeResponse {
             return nil
         }
         
-        guard let messageType = NodeMessageType(rawValue: typeRaw) else {
+        guard let messageType = NodeMessageType(rawValue: (typeRaw & ~RESPONSE_TYPE_FLAG)) else {
             print("NodeResponse::fromData(): Unknown message type in response")
             return nil
         }


### PR DESCRIPTION
Fixes IOS-73 and IOS-74.

- Adds preliminary routing for choosing the best way to send a message to a Probe (directly or over MeatNet)
- Updates maximum prediction temperature to 100 C. 
- Adds sending Set Prediction messages over MeatNet.
- Adds callback handling for Set Prediction Node messages.