### PR TITLE
Added 'status notification stale' flag + timeout.

### DIFF
--- a/Sources/CombustionBLE/Device.swift
+++ b/Sources/CombustionBLE/Device.swift
@@ -129,6 +129,7 @@ public class Device : ObservableObject {
         }
     }
     
+    /// Updates whether the device is stale. Called on a timer interval by DeviceManager.
     func updateDeviceStale() {
         stale = Date().timeIntervalSince(lastUpdateTime) > Constants.STALE_TIMEOUT
         


### PR DESCRIPTION
- Set status notification timeout to 16 seconds instead of 15 to allow time for 3 notifications while cooking (0.2Hz)
- Removed predictionStale as it was redundant with status notification stale flag.