### PR TITLE
Feature/ios 121 meatnet log transfer support

### DIFF
--- a/Sources/CombustionBLE/Device.swift
+++ b/Sources/CombustionBLE/Device.swift
@@ -57,6 +57,12 @@ public class Device : ObservableObject {
     /// Device hardware revision
     @Published public internal(set) var hardwareRevision: String?
     
+    /// Device SKU
+    @Published public internal(set) var sku: String?
+    
+    /// Device lot #
+    @Published public internal(set) var manufacturingLot: String?
+    
     /// Current connection state of device
     @Published public internal(set) var connectionState: ConnectionState = .disconnected
     
@@ -152,6 +158,16 @@ public class Device : ObservableObject {
     
     func dfuComplete() {
         // Nothing to do on base implementation
+    }
+    
+    /// Updates SKU and Lot number based on Model Info string.
+    func updateSkuAndLot(modelInfo: String) {
+        // Parse the SKU and lot number, which are delimited by a ':'
+        let parts = modelInfo.components(separatedBy: ":")
+        if parts.count == 2 {
+            self.sku = parts[0]
+            self.manufacturingLot = parts[1]
+        }
     }
 }
     

--- a/Sources/CombustionBLE/LoggedProbeDataPoint.swift
+++ b/Sources/CombustionBLE/LoggedProbeDataPoint.swift
@@ -72,6 +72,20 @@ extension LoggedProbeDataPoint {
                                     predictionValueSeconds: UInt(logResponse.predictionLog.predictionValueSeconds),
                                     estimatedCoreTemperature: logResponse.predictionLog.estimatedCoreTemperature)
     }
+    
+    static func fromLogResponse(logResponse: NodeReadLogsResponse) -> LoggedProbeDataPoint {
+        return LoggedProbeDataPoint(sequenceNum: logResponse.sequenceNumber,
+                                    temperatures: logResponse.temperatures,
+                                    virtualCore: logResponse.predictionLog.virtualSensors.virtualCore,
+                                    virtualSurface: logResponse.predictionLog.virtualSensors.virtualSurface,
+                                    virtualAmbient: logResponse.predictionLog.virtualSensors.virtualAmbient,
+                                    predictionState: logResponse.predictionLog.predictionState,
+                                    predictionMode: logResponse.predictionLog.predictionMode,
+                                    predictionType: logResponse.predictionLog.predictionType,
+                                    predictionSetPointTemperature: logResponse.predictionLog.predictionSetPointTemperature,
+                                    predictionValueSeconds: UInt(logResponse.predictionLog.predictionValueSeconds),
+                                    estimatedCoreTemperature: logResponse.predictionLog.estimatedCoreTemperature)
+    }
 }
 
 

--- a/Sources/CombustionBLE/UART/MeatNet/NodeMessageType.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeMessageType.swift
@@ -38,7 +38,7 @@ enum NodeMessageType: UInt8  {
     case disconnected = 0x41
     case readNodeList = 0x42
     case readNetworkTopology = 0x43
-    case probeSessionChanged = 0x44
+    case readProbeList = 0x44
     case probeStatus = 0x45
     case probeFirmwareRevision = 0x46
     case probeHardwareRevision = 0x47

--- a/Sources/CombustionBLE/UART/MeatNet/NodeProbeStatusRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeProbeStatusRequest.swift
@@ -55,7 +55,7 @@ class NodeProbeStatusRequest: NodeRequest {
             self.hopCount = hc
         }
         
-        super.init(requestId: requestId, payLoadLength: payloadLength)
+        super.init(requestId: requestId, payloadLength: payloadLength)
     }
 }
 

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadFirmwareRevisionRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadFirmwareRevisionRequest.swift
@@ -1,4 +1,4 @@
-//  NodeUARTMessage.swift
+//  NodeReadFirmwareRevisionRequest.swift
 
 /*--
 MIT License
@@ -26,29 +26,13 @@ SOFTWARE.
 
 import Foundation
 
-/// Class representing a Combustion BLE Node UART request.
-class NodeUARTMessage {
-    static func fromData(_ data : Data) -> [NodeUARTMessage] {
-        var messages = [NodeUARTMessage]()
+class NodeReadFirmwareRevisionRequest: NodeRequest {
+    init(serialNumber: UInt32) {
+        var payload = Data()
+        var serialNumberBytes = serialNumber
+        payload.append(Data(bytes: &serialNumberBytes, count: MemoryLayout.size(ofValue: serialNumberBytes)))
         
-        var numberBytesRead = 0
-        
-        while(numberBytesRead < data.count) {
-            let bytesToDecode = data.subdata(in: numberBytesRead..<data.count)
-            if let response = NodeResponse.responseFromData(bytesToDecode) {
-                messages.append(response)
-                numberBytesRead += (response.payloadLength + NodeResponse.HEADER_LENGTH)
-                
-            } else if let request = NodeRequest.requestFromData(bytesToDecode) {
-                messages.append(request)
-                numberBytesRead += (request.payloadLength + NodeRequest.HEADER_LENGTH)
-                
-            } else {
-                // Found invalid response, break out of while loop
-                break
-            }
-        }
-        
-        return messages
+        super.init(outgoingPayload: payload, type: .probeFirmwareRevision)
     }
 }
+

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadFirmwareRevisionResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadFirmwareRevisionResponse.swift
@@ -1,4 +1,4 @@
-//  NodeReadSessionInfoResponse.swift
+//  NodeReadFirmwareRevisionResponse.swift
 
 /*--
 MIT License
@@ -26,49 +26,38 @@ SOFTWARE.
 
 import Foundation
 
-class NodeReadSessionInfoResponse: NodeResponse {
+class NodeReadFirmwareRevisionResponse: NodeResponse {
     
     enum Constants {
-        static let MINIMUM_PAYLOAD_LENGTH = 10
+        static let MINIMUM_PAYLOAD_LENGTH = 24
         
         static let SERIAL_RANGE = NodeResponse.HEADER_LENGTH..<(NodeResponse.HEADER_LENGTH + 4)
-        static let SESSION_ID_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 8)
-        static let SAMPLE_PERIOD_RANGE = (NodeResponse.HEADER_LENGTH + 8)..<(NodeResponse.HEADER_LENGTH + 10)
+        static let FW_REVISION_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 24)
     }
     
     let probeSerialNumber: UInt32
+    let fwRevision: String
     
-    let info: SessionInformation
-
     init(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) {
         let serialRaw = data.subdata(in: Constants.SERIAL_RANGE)
         probeSerialNumber = serialRaw.withUnsafeBytes {
             $0.load(as: UInt32.self)
         }
         
-        let sessionIdRaw = data.subdata(in: Constants.SESSION_ID_RANGE)
-        let sessionId = sessionIdRaw.withUnsafeBytes {
-            $0.load(as: UInt32.self)
-        }
-        
-        let samplePeriodRaw = data.subdata(in: Constants.SAMPLE_PERIOD_RANGE)
-        let samplePeriod = samplePeriodRaw.withUnsafeBytes {
-            $0.load(as: UInt16.self)
-        }
-        
-        info = SessionInformation(sessionID: sessionId, samplePeriod: samplePeriod)
+        let fwRevisionRaw = data.subdata(in: Constants.FW_REVISION_RANGE)
+        fwRevision = String(decoding: fwRevisionRaw, as: UTF8.self).trimmingCharacters(in: CharacterSet(["\0"]))
         
         super.init(success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }
 
-extension NodeReadSessionInfoResponse {
+extension NodeReadFirmwareRevisionResponse {
 
-    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadSessionInfoResponse? {
+    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadFirmwareRevisionResponse? {
         if(payloadLength < Constants.MINIMUM_PAYLOAD_LENGTH) {
             return nil
         }
             
-        return NodeReadSessionInfoResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
+        return NodeReadFirmwareRevisionResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadHardwareRevisionRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadHardwareRevisionRequest.swift
@@ -1,4 +1,4 @@
-//  NodeUARTMessage.swift
+//  NodeReadHardwareRevisionRequest.swift
 
 /*--
 MIT License
@@ -26,29 +26,13 @@ SOFTWARE.
 
 import Foundation
 
-/// Class representing a Combustion BLE Node UART request.
-class NodeUARTMessage {
-    static func fromData(_ data : Data) -> [NodeUARTMessage] {
-        var messages = [NodeUARTMessage]()
+class NodeReadHardwareRevisionRequest: NodeRequest {
+    init(serialNumber: UInt32) {
+        var payload = Data()
+        var serialNumberBytes = serialNumber
+        payload.append(Data(bytes: &serialNumberBytes, count: MemoryLayout.size(ofValue: serialNumberBytes)))
         
-        var numberBytesRead = 0
-        
-        while(numberBytesRead < data.count) {
-            let bytesToDecode = data.subdata(in: numberBytesRead..<data.count)
-            if let response = NodeResponse.responseFromData(bytesToDecode) {
-                messages.append(response)
-                numberBytesRead += (response.payloadLength + NodeResponse.HEADER_LENGTH)
-                
-            } else if let request = NodeRequest.requestFromData(bytesToDecode) {
-                messages.append(request)
-                numberBytesRead += (request.payloadLength + NodeRequest.HEADER_LENGTH)
-                
-            } else {
-                // Found invalid response, break out of while loop
-                break
-            }
-        }
-        
-        return messages
+        super.init(outgoingPayload: payload, type: .probeHardwareRevision)
     }
 }
+

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadHardwareRevisionResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadHardwareRevisionResponse.swift
@@ -1,4 +1,4 @@
-//  NodeReadSessionInfoResponse.swift
+//  NodeReadHardwareRevisionResponse.swift
 
 /*--
 MIT License
@@ -26,49 +26,38 @@ SOFTWARE.
 
 import Foundation
 
-class NodeReadSessionInfoResponse: NodeResponse {
+class NodeReadHardwareRevisionResponse: NodeResponse {
     
     enum Constants {
-        static let MINIMUM_PAYLOAD_LENGTH = 10
+        static let MINIMUM_PAYLOAD_LENGTH = 20
         
         static let SERIAL_RANGE = NodeResponse.HEADER_LENGTH..<(NodeResponse.HEADER_LENGTH + 4)
-        static let SESSION_ID_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 8)
-        static let SAMPLE_PERIOD_RANGE = (NodeResponse.HEADER_LENGTH + 8)..<(NodeResponse.HEADER_LENGTH + 10)
+        static let HW_REVISION_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 20)
     }
     
     let probeSerialNumber: UInt32
+    let hwRevision: String
     
-    let info: SessionInformation
-
     init(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) {
         let serialRaw = data.subdata(in: Constants.SERIAL_RANGE)
         probeSerialNumber = serialRaw.withUnsafeBytes {
             $0.load(as: UInt32.self)
         }
         
-        let sessionIdRaw = data.subdata(in: Constants.SESSION_ID_RANGE)
-        let sessionId = sessionIdRaw.withUnsafeBytes {
-            $0.load(as: UInt32.self)
-        }
-        
-        let samplePeriodRaw = data.subdata(in: Constants.SAMPLE_PERIOD_RANGE)
-        let samplePeriod = samplePeriodRaw.withUnsafeBytes {
-            $0.load(as: UInt16.self)
-        }
-        
-        info = SessionInformation(sessionID: sessionId, samplePeriod: samplePeriod)
+        let hwRevisionRaw = data.subdata(in: Constants.HW_REVISION_RANGE)
+        hwRevision = String(decoding: hwRevisionRaw, as: UTF8.self).trimmingCharacters(in: CharacterSet(["\0"]))
         
         super.init(success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }
 
-extension NodeReadSessionInfoResponse {
+extension NodeReadHardwareRevisionResponse {
 
-    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadSessionInfoResponse? {
+    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadHardwareRevisionResponse? {
         if(payloadLength < Constants.MINIMUM_PAYLOAD_LENGTH) {
             return nil
         }
             
-        return NodeReadSessionInfoResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
+        return NodeReadHardwareRevisionResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadLogsRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadLogsRequest.swift
@@ -1,4 +1,4 @@
-//  NodeUARTMessage.swift
+//  NodeReadLogsRequest.swift
 
 /*--
 MIT License
@@ -26,29 +26,19 @@ SOFTWARE.
 
 import Foundation
 
-/// Class representing a Combustion BLE Node UART request.
-class NodeUARTMessage {
-    static func fromData(_ data : Data) -> [NodeUARTMessage] {
-        var messages = [NodeUARTMessage]()
+class NodeReadLogsRequest: NodeRequest {
+    init(serialNumber: UInt32, minSequence: UInt32, maxSequence: UInt32) {
+        var payload = Data()
+        var serialNumberBytes = serialNumber
+        payload.append(Data(bytes: &serialNumberBytes, count: MemoryLayout.size(ofValue: serialNumberBytes)))
         
-        var numberBytesRead = 0
+        var min = minSequence
+        payload.append(Data(bytes: &min, count: MemoryLayout.size(ofValue: min)))
         
-        while(numberBytesRead < data.count) {
-            let bytesToDecode = data.subdata(in: numberBytesRead..<data.count)
-            if let response = NodeResponse.responseFromData(bytesToDecode) {
-                messages.append(response)
-                numberBytesRead += (response.payloadLength + NodeResponse.HEADER_LENGTH)
-                
-            } else if let request = NodeRequest.requestFromData(bytesToDecode) {
-                messages.append(request)
-                numberBytesRead += (request.payloadLength + NodeRequest.HEADER_LENGTH)
-            }
-            else {
-                // Found invalid response, break out of while loop
-                break
-            }
-        }
+        var max = maxSequence
+        payload.append(Data(bytes: &max, count: MemoryLayout.size(ofValue: max)))
         
-        return messages
+        super.init(outgoingPayload: payload, type: .log)
     }
 }
+

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadLogsResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadLogsResponse.swift
@@ -1,4 +1,4 @@
-//  LogResponse.swift
+//  NodeReadLogsResponse.swift
 
 /*--
 MIT License
@@ -26,21 +26,28 @@ SOFTWARE.
 
 import Foundation
 
-class LogResponse: Response {
+class NodeReadLogsResponse: NodeResponse {
     
     enum Constants {
-        static let MINIMUM_PAYLOAD_LENGTH = 19
+        static let MINIMUM_PAYLOAD_LENGTH = 28
         
-        static let SEQUENCE_RANGE = Response.HEADER_LENGTH..<(Response.HEADER_LENGTH + 4)
-        static let TEMPERATURE_RANGE = (Response.HEADER_LENGTH + 4)..<(Response.HEADER_LENGTH + 17)
-        static let PREDICTION_LOG_RANGE = (Response.HEADER_LENGTH + 17)..<(Response.HEADER_LENGTH + 24)
+        static let SERIAL_RANGE = NodeResponse.HEADER_LENGTH..<(NodeResponse.HEADER_LENGTH + 4)
+        static let SEQUENCE_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 8)
+        static let TEMPERATURE_RANGE = (NodeResponse.HEADER_LENGTH + 8)..<(NodeResponse.HEADER_LENGTH + 21)
+        static let PREDICTION_LOG_RANGE = (NodeResponse.HEADER_LENGTH + 21)..<(NodeResponse.HEADER_LENGTH + 28)
     }
     
+    let probeSerialNumber: UInt32
     let sequenceNumber: UInt32
     let temperatures: ProbeTemperatures
     let predictionLog: PredictionLog
     
-    init(data: Data, success: Bool, payloadLength: Int) {
+    init(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) {
+        let serialRaw = data.subdata(in: Constants.SERIAL_RANGE)
+        probeSerialNumber = serialRaw.withUnsafeBytes {
+            $0.load(as: UInt32.self)
+        }
+        
         let sequenceRaw = data.subdata(in: Constants.SEQUENCE_RANGE)
         sequenceNumber = sequenceRaw.withUnsafeBytes {
             $0.load(as: UInt32.self)
@@ -54,17 +61,17 @@ class LogResponse: Response {
         let predictionLogData = data.subdata(in: Constants.PREDICTION_LOG_RANGE)
         predictionLog = PredictionLog.fromRaw(data: predictionLogData)
 
-        super.init(success: success, payloadLength: payloadLength)
+        super.init(success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }
 
-extension LogResponse {
+extension NodeReadLogsResponse {
 
-    static func fromRaw(data: Data, success: Bool, payloadLength: Int) -> LogResponse? {
+    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadLogsResponse? {
         if(payloadLength < Constants.MINIMUM_PAYLOAD_LENGTH) {
             return nil
         }
             
-        return LogResponse(data: data, success: success, payloadLength: payloadLength)
+        return NodeReadLogsResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadModelInfoRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadModelInfoRequest.swift
@@ -1,4 +1,4 @@
-//  NodeUARTMessage.swift
+//  NodeReadModelInfoRequest.swift
 
 /*--
 MIT License
@@ -26,29 +26,13 @@ SOFTWARE.
 
 import Foundation
 
-/// Class representing a Combustion BLE Node UART request.
-class NodeUARTMessage {
-    static func fromData(_ data : Data) -> [NodeUARTMessage] {
-        var messages = [NodeUARTMessage]()
+class NodeReadModelInfoRequest: NodeRequest {
+    init(serialNumber: UInt32) {
+        var payload = Data()
+        var serialNumberBytes = serialNumber
+        payload.append(Data(bytes: &serialNumberBytes, count: MemoryLayout.size(ofValue: serialNumberBytes)))
         
-        var numberBytesRead = 0
-        
-        while(numberBytesRead < data.count) {
-            let bytesToDecode = data.subdata(in: numberBytesRead..<data.count)
-            if let response = NodeResponse.responseFromData(bytesToDecode) {
-                messages.append(response)
-                numberBytesRead += (response.payloadLength + NodeResponse.HEADER_LENGTH)
-                
-            } else if let request = NodeRequest.requestFromData(bytesToDecode) {
-                messages.append(request)
-                numberBytesRead += (request.payloadLength + NodeRequest.HEADER_LENGTH)
-                
-            } else {
-                // Found invalid response, break out of while loop
-                break
-            }
-        }
-        
-        return messages
+        super.init(outgoingPayload: payload, type: .probeModelInformation)
     }
 }
+

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadModelInfoResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadModelInfoResponse.swift
@@ -1,4 +1,4 @@
-//  NodeReadSessionInfoResponse.swift
+//  NodeReadModelInfoResponse.swift
 
 /*--
 MIT License
@@ -26,49 +26,38 @@ SOFTWARE.
 
 import Foundation
 
-class NodeReadSessionInfoResponse: NodeResponse {
+class NodeReadModelInfoResponse: NodeResponse {
     
     enum Constants {
-        static let MINIMUM_PAYLOAD_LENGTH = 10
+        static let MINIMUM_PAYLOAD_LENGTH = 54
         
         static let SERIAL_RANGE = NodeResponse.HEADER_LENGTH..<(NodeResponse.HEADER_LENGTH + 4)
-        static let SESSION_ID_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 8)
-        static let SAMPLE_PERIOD_RANGE = (NodeResponse.HEADER_LENGTH + 8)..<(NodeResponse.HEADER_LENGTH + 10)
+        static let MODEL_INFO_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 54)
     }
     
     let probeSerialNumber: UInt32
+    let modelInfo: String
     
-    let info: SessionInformation
-
     init(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) {
         let serialRaw = data.subdata(in: Constants.SERIAL_RANGE)
         probeSerialNumber = serialRaw.withUnsafeBytes {
             $0.load(as: UInt32.self)
         }
         
-        let sessionIdRaw = data.subdata(in: Constants.SESSION_ID_RANGE)
-        let sessionId = sessionIdRaw.withUnsafeBytes {
-            $0.load(as: UInt32.self)
-        }
-        
-        let samplePeriodRaw = data.subdata(in: Constants.SAMPLE_PERIOD_RANGE)
-        let samplePeriod = samplePeriodRaw.withUnsafeBytes {
-            $0.load(as: UInt16.self)
-        }
-        
-        info = SessionInformation(sessionID: sessionId, samplePeriod: samplePeriod)
+        let modelInfoRaw = data.subdata(in: Constants.MODEL_INFO_RANGE)
+        modelInfo = String(decoding: modelInfoRaw, as: UTF8.self).trimmingCharacters(in: CharacterSet(["\0"]))
         
         super.init(success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }
 
-extension NodeReadSessionInfoResponse {
+extension NodeReadModelInfoResponse {
 
-    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadSessionInfoResponse? {
+    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadModelInfoResponse? {
         if(payloadLength < Constants.MINIMUM_PAYLOAD_LENGTH) {
             return nil
         }
             
-        return NodeReadSessionInfoResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
+        return NodeReadModelInfoResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
     }
 }

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadSessionInfoRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadSessionInfoRequest.swift
@@ -1,4 +1,4 @@
-//  NodeUARTMessage.swift
+//  NodeReadSessionInfoRequest.swift
 
 /*--
 MIT License
@@ -26,29 +26,13 @@ SOFTWARE.
 
 import Foundation
 
-/// Class representing a Combustion BLE Node UART request.
-class NodeUARTMessage {
-    static func fromData(_ data : Data) -> [NodeUARTMessage] {
-        var messages = [NodeUARTMessage]()
+class NodeReadSessionInfoRequest: NodeRequest {
+    init(serialNumber: UInt32) {
+        var payload = Data()
+        var serialNumberBytes = serialNumber
+        payload.append(Data(bytes: &serialNumberBytes, count: MemoryLayout.size(ofValue: serialNumberBytes)))
         
-        var numberBytesRead = 0
-        
-        while(numberBytesRead < data.count) {
-            let bytesToDecode = data.subdata(in: numberBytesRead..<data.count)
-            if let response = NodeResponse.responseFromData(bytesToDecode) {
-                messages.append(response)
-                numberBytesRead += (response.payloadLength + NodeResponse.HEADER_LENGTH)
-                
-            } else if let request = NodeRequest.requestFromData(bytesToDecode) {
-                messages.append(request)
-                numberBytesRead += (request.payloadLength + NodeRequest.HEADER_LENGTH)
-            }
-            else {
-                // Found invalid response, break out of while loop
-                break
-            }
-        }
-        
-        return messages
+        super.init(outgoingPayload: payload, type: .sessionInfo)
     }
 }
+

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadSessionInfoResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadSessionInfoResponse.swift
@@ -1,0 +1,73 @@
+//  NodeReadSessionInfoResponse.swift
+
+/*--
+MIT License
+
+Copyright (c) 2021 Combustion Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--*/
+
+import Foundation
+
+class NodeReadSessionInfoResponse: NodeResponse {
+    
+    enum Constants {
+        static let MINIMUM_PAYLOAD_LENGTH = 10
+        
+        static let SERIAL_RANGE = NodeResponse.HEADER_LENGTH..<(NodeResponse.HEADER_LENGTH + 4)
+        static let SESSION_ID_RANGE = (NodeResponse.HEADER_LENGTH + 4)..<(NodeResponse.HEADER_LENGTH + 8)
+        static let SAMPLE_RATE_RANGE = (NodeResponse.HEADER_LENGTH + 8)..<(NodeResponse.HEADER_LENGTH + 10)
+    }
+    
+    let probeSerialNumber: UInt32
+    let sessionId: UInt32
+    let sampleRate: UInt16
+    
+    init(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) {
+        let serialRaw = data.subdata(in: Constants.SERIAL_RANGE)
+        probeSerialNumber = serialRaw.withUnsafeBytes {
+            $0.load(as: UInt32.self)
+        }
+        
+        let sessionIdRaw = data.subdata(in: Constants.SESSION_ID_RANGE)
+        sessionId = sessionIdRaw.withUnsafeBytes {
+            $0.load(as: UInt32.self)
+        }
+        
+        let sampleRateRaw = data.subdata(in: Constants.SAMPLE_RATE_RANGE)
+        sampleRate = sampleRateRaw.withUnsafeBytes {
+            $0.load(as: UInt16.self)
+        }
+        
+        
+        super.init(success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
+    }
+}
+
+extension NodeReadSessionInfoResponse {
+
+    static func fromRaw(data: Data, success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) -> NodeReadSessionInfoResponse? {
+        if(payloadLength < Constants.MINIMUM_PAYLOAD_LENGTH) {
+            return nil
+        }
+            
+        return NodeReadSessionInfoResponse(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: payloadLength)
+    }
+}

--- a/Sources/CombustionBLE/UART/MeatNet/NodeRequest.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeRequest.swift
@@ -38,7 +38,7 @@ class NodeRequest : NodeUARTMessage {
     var requestId : UInt32
     
     /// Length of payload
-    let payLoadLength: Int
+    let payloadLength: Int
     
     /// Constructor for generating a new Request object.
     /// - parameter payloadLength: Length of payload of message
@@ -73,15 +73,15 @@ class NodeRequest : NodeUARTMessage {
         // Message Type, payload length, payload
         data.append(crcData)
         
-        self.payLoadLength = outgoingPayload.count
+        self.payloadLength = outgoingPayload.count
     }
     
     
     /// Constructor for an incoming Request object (from MeatNet).
     /// - parameter requestId: Request ID of this message from the Network
     /// - parameter payloadLength: Length of this message's payload
-    init(requestId: UInt32, payLoadLength: Int) {
-        self.payLoadLength = payLoadLength
+    init(requestId: UInt32, payloadLength: Int) {
+        self.payloadLength = payloadLength
         self.requestId = requestId
     }
     
@@ -151,9 +151,9 @@ extension NodeRequest {
 //        case .log:
 //            return NodeLogResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
 //        case .setID:
-//            return NodeSetIDResponse(success: success, payLoadLength: Int(payloadLength))
+//            return NodeSetIDResponse(success: success, payloadLength: Int(payloadLength))
 //        case .setColor:
-//            return NodeSetColorResponse(success: success, payLoadLength: Int(payloadLength))
+//            return NodeSetColorResponse(success: success, payloadLength: Int(payloadLength))
 //        case .sessionInfo:
 //            return NodeSessionInfoResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
         case .probeStatus:

--- a/Sources/CombustionBLE/UART/MeatNet/NodeResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeResponse.swift
@@ -120,6 +120,7 @@ extension NodeResponse {
         
         // Invalid number of bytes
         if(data.count < responseLength) {
+            print("Bad number of bytes")
             return nil
         }
         
@@ -136,6 +137,12 @@ extension NodeResponse {
             return NodeReadSessionInfoResponse.fromRaw(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
         case .setPrediction:
             return NodeSetPredictionResponse(success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
+        case .probeFirmwareRevision:
+            return NodeReadFirmwareRevisionResponse.fromRaw(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
+        case .probeHardwareRevision:
+            return NodeReadHardwareRevisionResponse.fromRaw(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
+        case .probeModelInformation:
+            return NodeReadModelInfoResponse.fromRaw(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
 //        case .readOverTemperature:
 //            return NodeReadOverTemperatureResponse(data: data, success: success, payloadLength: Int(payloadLength))
         default:

--- a/Sources/CombustionBLE/UART/MeatNet/NodeResponse.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeResponse.swift
@@ -33,14 +33,14 @@ class NodeResponse : NodeUARTMessage {
     static let RESPONSE_TYPE_FLAG : UInt8 = 0x80
     
     let success: Bool
-    let payLoadLength: Int
+    let payloadLength: Int
     
     let requestId: UInt32
     let responseId: UInt32
     
-    init(success: Bool, requestId: UInt32, responseId: UInt32, payLoadLength: Int) {
+    init(success: Bool, requestId: UInt32, responseId: UInt32, payloadLength: Int) {
         self.success = success
-        self.payLoadLength = payLoadLength
+        self.payloadLength = payloadLength
         self.requestId = requestId
         self.responseId = responseId
     }
@@ -126,16 +126,16 @@ extension NodeResponse {
         // print("Success: \(success), payloadLength: \(payloadLength)")
         
         switch messageType {
-//        case .log:
-//            return NodeLogResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
+        case .log:
+            return NodeReadLogsResponse.fromRaw(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
 //        case .setID:
-//            return NodeSetIDResponse(success: success, payLoadLength: Int(payloadLength))
+//            return NodeSetIDResponse(success: success, payloadLength: Int(payloadLength))
 //        case .setColor:
-//            return NodeSetColorResponse(success: success, payLoadLength: Int(payloadLength))
-//        case .sessionInfo:
-//            return NodeSessionInfoResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
+//            return NodeSetColorResponse(success: success, payloadLength: Int(payloadLength))
+        case .sessionInfo:
+            return NodeReadSessionInfoResponse.fromRaw(data: data, success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
         case .setPrediction:
-            return NodeSetPredictionResponse(success: success, requestId: requestId, responseId: responseId, payLoadLength: Int(payloadLength))
+            return NodeSetPredictionResponse(success: success, requestId: requestId, responseId: responseId, payloadLength: Int(payloadLength))
 //        case .readOverTemperature:
 //            return NodeReadOverTemperatureResponse(data: data, success: success, payloadLength: Int(payloadLength))
         default:

--- a/Sources/CombustionBLE/UART/ReadOverTemperature.swift
+++ b/Sources/CombustionBLE/UART/ReadOverTemperature.swift
@@ -45,6 +45,6 @@ class ReadOverTemperatureResponse : Response {
             $0.load(as: Bool.self)
         }
 
-        super.init(success: success, payLoadLength: payloadLength)
+        super.init(success: success, payloadLength: payloadLength)
     }
 }

--- a/Sources/CombustionBLE/UART/Response.swift
+++ b/Sources/CombustionBLE/UART/Response.swift
@@ -30,11 +30,11 @@ class Response {
     static let HEADER_LENGTH = 7
     
     let success: Bool
-    let payLoadLength: Int
+    let payloadLength: Int
     
-    init(success: Bool, payLoadLength: Int) {
+    init(success: Bool, payloadLength: Int) {
         self.success = success
-        self.payLoadLength = payLoadLength
+        self.payloadLength = payloadLength
     }
 }
 
@@ -48,7 +48,7 @@ extension Response {
             let bytesToDecode = data.subdata(in: numberBytesRead..<data.count)
             if let response = responseFromData(bytesToDecode) {
                 responses.append(response)
-                numberBytesRead += (response.payLoadLength + Response.HEADER_LENGTH)
+                numberBytesRead += (response.payloadLength + Response.HEADER_LENGTH)
             }
             else {
                 // Found invalid response, break out of while loop
@@ -121,13 +121,13 @@ extension Response {
         case .log:
             return LogResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
         case .setID:
-            return SetIDResponse(success: success, payLoadLength: Int(payloadLength))
+            return SetIDResponse(success: success, payloadLength: Int(payloadLength))
         case .setColor:
-            return SetColorResponse(success: success, payLoadLength: Int(payloadLength))
+            return SetColorResponse(success: success, payloadLength: Int(payloadLength))
         case .sessionInfo:
             return SessionInfoResponse.fromRaw(data: data, success: success, payloadLength: Int(payloadLength))
         case .setPrediction:
-            return SetPredictionResponse(success: success, payLoadLength: Int(payloadLength))
+            return SetPredictionResponse(success: success, payloadLength: Int(payloadLength))
         case .readOverTemperature:
             return ReadOverTemperatureResponse(data: data, success: success, payloadLength: Int(payloadLength))
         }

--- a/Sources/CombustionBLE/UART/SessionInfo.swift
+++ b/Sources/CombustionBLE/UART/SessionInfo.swift
@@ -56,7 +56,7 @@ class SessionInfoResponse: Response {
         
         info = SessionInformation(sessionID: sessionID, samplePeriod: samplePeriod)
 
-        super.init(success: success, payLoadLength: payloadLength)
+        super.init(success: success, payloadLength: payloadLength)
     }
 }
 


### PR DESCRIPTION
Resolves IOS-121 and IOS-72.

### Added transmission of log records, session info, and more over MeatNet.
Added reading of model info from Probe.
Added automatic re-reading of software version, hardware version, model info and session info for probe if any is missing when a status notification comes in.
Added MeatNet support for Log Records, Firmware Version, Software Version, Session Info and Model Info.
Added parsing of Model Info into Sku/Lot.
Updated log percentage calculation to work better when logs are missing.
Modified check for missing data to request range from the minimum gap to the maximum gap rather than entire range.