### PR TITLE
Decode overheating flags from probe

### DIFF
--- a/Sources/CombustionBLE/BleData/OverheatingSensors.swift
+++ b/Sources/CombustionBLE/BleData/OverheatingSensors.swift
@@ -1,0 +1,103 @@
+/*--
+MIT License
+
+Copyright (c) 2024 Combustion Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+--*/
+
+import Foundation
+
+public struct OverheatingSensors: Equatable {
+    public let sensorIndexes: [Int]
+    
+    public init(sensorIndexes: [Int]) {
+        self.sensorIndexes = sensorIndexes
+    }
+}
+
+extension OverheatingSensors {
+    public func isAnySensorOverheating() -> Bool {
+        return !sensorIndexes.isEmpty
+    }
+}
+
+extension OverheatingSensors {
+    
+    /// Overheating thresholds for each sensor (in degrees C)
+    private static let OVERHEATING_THRESHOLDS: [Double] = [
+        105.0, // T1
+        105.0, // T2
+        115.0, // T3
+        125.0, // T4
+        315.56, // T5
+        315.56, // T6
+        315.56, // T7
+        315.56, // T8
+    ]
+
+    static func fromByte(_ byte: UInt8) -> OverheatingSensors {
+        var sensorIndexes = [Int]()
+        for i in 0..<8 {
+            if (byte & (1 << i)) != 0 {
+                sensorIndexes.append(i)
+            }
+        }
+        
+        return OverheatingSensors(sensorIndexes: sensorIndexes)
+    }
+    
+    public func toInt() -> Int {
+        var mask: UInt8 = 0
+        for index in sensorIndexes {
+            mask = mask | (1 << index)
+        }
+        
+        return Int(mask)
+    }
+    
+    public static func fromBools(_ flags: [Bool]?) -> OverheatingSensors {
+        guard let flags else { return OverheatingSensors(sensorIndexes: [])}
+        
+        var sensorIndexes : [Int] = []
+            
+        // Check T1-T8
+        for (index, flag) in flags.enumerated() {
+            if flag {
+                sensorIndexes.append(index)
+            }
+        }
+        
+        return OverheatingSensors(sensorIndexes: sensorIndexes)
+    }
+    
+    /// Find overheating sensors by comparing against threshold for each temperature
+    static func fromTemperatures(_ temperatures: [Double]) -> OverheatingSensors{
+        var sensorIndexes : [Int] = []
+            
+        // Check T1-T8
+        for i in 0...7 {
+            if temperatures[i] >= OVERHEATING_THRESHOLDS[i] {
+                sensorIndexes.append(i)
+            }
+        }
+        
+        return OverheatingSensors(sensorIndexes: sensorIndexes)
+    }
+}

--- a/Sources/CombustionBLE/BleData/ProbeStatus.swift
+++ b/Sources/CombustionBLE/BleData/ProbeStatus.swift
@@ -52,6 +52,9 @@ public struct ProbeStatus {
     /// Food Safe Status
     public let foodSafeStatus: FoodSafeStatus?
     
+    /// Overheating sensors
+    public let overheatingSensors: [Int]
+    
     public init(minSequenceNumber: UInt32,
                 maxSequenceNumber: UInt32,
                 temperatures: ProbeTemperatures,
@@ -59,7 +62,8 @@ public struct ProbeStatus {
                 batteryStatusVirtualSensors: BatteryStatusVirtualSensors,
                 predictionStatus: PredictionStatus,
                 foodSafeData: FoodSafeData?,
-                foodSafeStatus: FoodSafeStatus?) {
+                foodSafeStatus: FoodSafeStatus?,
+                overheatingSensors: [Int]) {
         self.minSequenceNumber = minSequenceNumber
         self.maxSequenceNumber = maxSequenceNumber
         self.temperatures = temperatures
@@ -68,6 +72,7 @@ public struct ProbeStatus {
         self.predictionStatus = predictionStatus
         self.foodSafeData = foodSafeData
         self.foodSafeStatus = foodSafeStatus
+        self.overheatingSensors = overheatingSensors
     }
 }
 
@@ -82,6 +87,7 @@ extension ProbeStatus {
         static let PREDICTION_STATUS_RANGE = 23..<30
         static let FOOD_SAFE_DATA_RANGE = 30..<40
         static let FOOD_SAFE_STATUS_RANGE = 40..<48
+        static let OVERHEAT_BYTE_RANGE = 48..<49
     }
     
     init?(fromData data: Data) {
@@ -131,6 +137,22 @@ extension ProbeStatus {
         }
         else {
             foodSafeStatus = nil
+        }
+        
+        // Decode Over heating flags
+        if data.count >= Constants.OVERHEAT_BYTE_RANGE.endIndex {
+            let data = data.subdata(in: Constants.OVERHEAT_BYTE_RANGE)
+            var sensors = [Int]()
+            for i in 0..<8 {
+                if (data[0] & (1 << i)) != 0 {
+                    sensors.append(i)
+                }
+            }
+            overheatingSensors = sensors
+        }
+        else {
+            // If status does not contain flags, then calculate from temperatures
+            overheatingSensors = Probe.findOverheatingSensors(temperatures.values)
         }
     }
 }

--- a/Sources/CombustionBLE/BleData/ProbeStatus.swift
+++ b/Sources/CombustionBLE/BleData/ProbeStatus.swift
@@ -53,7 +53,7 @@ public struct ProbeStatus {
     public let foodSafeStatus: FoodSafeStatus?
     
     /// Overheating sensors
-    public let overheatingSensors: [Int]
+    public let overheatingSensors: OverheatingSensors
     
     public init(minSequenceNumber: UInt32,
                 maxSequenceNumber: UInt32,
@@ -63,7 +63,7 @@ public struct ProbeStatus {
                 predictionStatus: PredictionStatus,
                 foodSafeData: FoodSafeData?,
                 foodSafeStatus: FoodSafeStatus?,
-                overheatingSensors: [Int]) {
+                overheatingSensors: OverheatingSensors) {
         self.minSequenceNumber = minSequenceNumber
         self.maxSequenceNumber = maxSequenceNumber
         self.temperatures = temperatures
@@ -141,18 +141,12 @@ extension ProbeStatus {
         
         // Decode Over heating flags
         if data.count >= Constants.OVERHEAT_BYTE_RANGE.endIndex {
-            let data = data.subdata(in: Constants.OVERHEAT_BYTE_RANGE)
-            var sensors = [Int]()
-            for i in 0..<8 {
-                if (data[0] & (1 << i)) != 0 {
-                    sensors.append(i)
-                }
-            }
-            overheatingSensors = sensors
+            let byte = data.subdata(in: Constants.OVERHEAT_BYTE_RANGE)[0]
+            overheatingSensors = OverheatingSensors.fromByte(byte)
         }
         else {
             // If status does not contain flags, then calculate from temperatures
-            overheatingSensors = Probe.findOverheatingSensors(temperatures.values)
+            overheatingSensors = OverheatingSensors.fromTemperatures(temperatures.values)
         }
     }
 }

--- a/Sources/CombustionBLE/Devices/Probe.swift
+++ b/Sources/CombustionBLE/Devices/Probe.swift
@@ -149,34 +149,6 @@ open class Probe : Device {
     /// Last hop count that updated 'normal mode' info (nil = direct from Probe)
     @Published public internal(set) var lastNormalModeHopCount : HopCount? = nil
     
-    /// Overheating thresholds for each sensor (in degrees C)
-    private static let OVERHEATING_THRESHOLDS: [Double] = [
-        105.0, // T1
-        105.0, // T2
-        115.0, // T3
-        125.0, // T4
-        315.56, // T5
-        315.56, // T6
-        315.56, // T7
-        315.56, // T8
-    ]
-    
-    /// Find overheating sensors by comparing against threshold for each temperature
-    static func findOverheatingSensors(_ temperatures: [Double]?) -> [Int] {
-        guard let temperatures = temperatures else { return [] }
-        
-        var overheatingSensorList : [Int] = []
-            
-        // Check T1-T8
-        for i in 0...7 {
-            if temperatures[i] >= Probe.OVERHEATING_THRESHOLDS[i] {
-                overheatingSensorList.append(i)
-            }
-        }
-        
-        return overheatingSensorList
-    }
-    
     private var predictionLinearizer = PredictionLinearizer()
     private var instantReadFilter = InstantReadFilter()
     private var deviceManager = DeviceManager.shared
@@ -360,7 +332,7 @@ extension Probe {
                 foodSafeStatus = deviceStatus.foodSafeStatus
                 
                 // Overheating sensors
-                overheatingSensors = deviceStatus.overheatingSensors
+                overheatingSensors = deviceStatus.overheatingSensors.sensorIndexes
                 overheating = !overheatingSensors.isEmpty
                 
                 // Log the temperature data point for "Normal" status updates

--- a/Sources/CombustionBLE/Devices/Probe.swift
+++ b/Sources/CombustionBLE/Devices/Probe.swift
@@ -150,7 +150,7 @@ open class Probe : Device {
     @Published public internal(set) var lastNormalModeHopCount : HopCount? = nil
     
     /// Overheating thresholds for each sensor (in degrees C)
-    public static let OVERHEATING_THRESHOLDS: [Double] = [
+    private static let OVERHEATING_THRESHOLDS: [Double] = [
         105.0, // T1
         105.0, // T2
         115.0, // T3
@@ -162,7 +162,7 @@ open class Probe : Device {
     ]
     
     /// Find overheating sensors by comparing against threshold for each temperature
-    public static func findOverheatingSensors(_ temperatures: [Double]?) -> [Int] {
+    static func findOverheatingSensors(_ temperatures: [Double]?) -> [Int] {
         guard let temperatures = temperatures else { return [] }
         
         var overheatingSensorList : [Int] = []
@@ -359,6 +359,10 @@ extension Probe {
                 foodSafeData = deviceStatus.foodSafeData
                 foodSafeStatus = deviceStatus.foodSafeStatus
                 
+                // Overheating sensors
+                overheatingSensors = deviceStatus.overheatingSensors
+                overheating = !overheatingSensors.isEmpty
+                
                 // Log the temperature data point for "Normal" status updates
                 addDataToLog(LoggedProbeDataPoint.fromDeviceStatus(deviceStatus: deviceStatus),
                              sampledAt: Date())
@@ -401,8 +405,8 @@ extension Probe {
             if let missingRange = missingRange {
                 // Request missing records
                 deviceManager.requestLogsFrom(self,
-                                                     minSequence: missingRange.lowerBound,
-                                                     maxSequence: missingRange.upperBound)
+                                              minSequence: missingRange.lowerBound,
+                                              maxSequence: missingRange.upperBound)
             }
         }
 
@@ -443,15 +447,6 @@ extension Probe {
         guard Date().timeIntervalSince(lastUpdateTime) > Constants.MINIMUM_LAST_UPDATE_CHANGE else { return }
         
         lastUpdateTime = Date()
-    }
-    
-    /// Checks if the probe is currently exceeding any temperature thresholds.
-    private func checkOverheating() {
-        guard let currentTemperatures = currentTemperatures else { return }
-        
-        // Publish overheating values
-        overheatingSensors = Probe.findOverheatingSensors(currentTemperatures.values)
-        overheating = !overheatingSensors.isEmpty
     }
     
     private func addDataToLog(_ dataPoint: LoggedProbeDataPoint, sampledAt: Date? = nil) {
@@ -613,9 +608,6 @@ extension Probe {
         virtualTemperatures = VirtualTemperatures(coreTemperature: core,
                                                   surfaceTemperature: surface,
                                                   ambientTemperature: ambient)
-        
-        // Check if the probe is overheating
-        checkOverheating()
     }
     
     private func requestSessionInformation() {

--- a/Sources/CombustionBLE/Devices/SimulatedProbe.swift
+++ b/Sources/CombustionBLE/Devices/SimulatedProbe.swift
@@ -107,7 +107,7 @@ public class SimulatedProbe: Probe {
                                       predictionStatus: predictionStatus,
                                       foodSafeData: nil,
                                       foodSafeStatus: nil,
-                                      overheatingSensors: [])
+                                      overheatingSensors: OverheatingSensors(sensorIndexes: []))
         
         updateProbeStatus(deviceStatus: probeStatus)
     }

--- a/Sources/CombustionBLE/Devices/SimulatedProbe.swift
+++ b/Sources/CombustionBLE/Devices/SimulatedProbe.swift
@@ -106,7 +106,8 @@ public class SimulatedProbe: Probe {
                                       batteryStatusVirtualSensors: BatteryStatusVirtualSensors.defaultValues(),
                                       predictionStatus: predictionStatus,
                                       foodSafeData: nil,
-                                      foodSafeStatus: nil)
+                                      foodSafeStatus: nil,
+                                      overheatingSensors: [])
         
         updateProbeStatus(deviceStatus: probeStatus)
     }


### PR DESCRIPTION
- Decode overheating flags from probe status
- Use previous temperature check if probe status does not contain flags
