### PR TITLE
Fix for feature flags being applied to wrong meat net node

### DIFF
--- a/Sources/CombustionBLE/DeviceManager.swift
+++ b/Sources/CombustionBLE/DeviceManager.swift
@@ -734,6 +734,31 @@ extension DeviceManager : BleManagerDelegate {
         return foundDevice
     }
     
+    /// Finds Device by serial number string
+    private func findDeviceBySerialNumber(serialNumber: String) -> Device? {
+        var foundDevice : Device? = nil
+        
+        // Search through Devices to see if any devices have matching serial number
+        for(_, device) in devices {
+            if let device = device as? MeatNetNode, let serialNumberString = device.serialNumberString {
+                if serialNumberString == serialNumber {
+                    // We found a device matching this identifier, so break
+                    foundDevice = device
+                    break
+                }
+            }
+            else if let device = device as? Probe {
+                if device.serialNumberString == serialNumber {
+                    // We found a device matching this identifier, so break
+                    foundDevice = device
+                    break
+                }
+            }
+        }
+        
+        return foundDevice
+    }
+    
     private func findProbeBySerialNumber(serialNumber: UInt32) -> Probe? {
         var foundProbe : Probe? = nil
         
@@ -882,7 +907,7 @@ extension DeviceManager : BleManagerDelegate {
                 }
         case .getFeatureFlags:
             if let featureFlagsResponse = response as? NodeReadFeatureFlagsResponse,
-               let device = findDeviceByBleIdentifier(bleIdentifier: identifier) as? MeatNetNode {
+               let device = findDeviceBySerialNumber(serialNumber: featureFlagsResponse.nodeSerialNumber) as? MeatNetNode {
                 device.updateFeatureFlags(featureFlagsResponse.flags)
             }
         case .setPrediction, .configureFoodSafe, .resetFoodSafe, .setPowerMode, .resetSession:

--- a/Sources/CombustionBLE/UART/MeatNet/NodeReadFeatureFlags.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeReadFeatureFlags.swift
@@ -46,7 +46,7 @@ class NodeReadFeatureFlagsResponse : NodeResponse {
     enum Constants {
         static let MINIMUM_PAYLOAD_LENGTH = 14
         
-        static let SERIAL_RANGE = NodeResponse.HEADER_LENGTH..<(NodeResponse.HEADER_LENGTH + 4)
+        static let SERIAL_RANGE = NodeResponse.HEADER_LENGTH..<(NodeResponse.HEADER_LENGTH + 10)
         static let FEATURE_FLAG_RANGE = (NodeResponse.HEADER_LENGTH + 10)..<(NodeResponse.HEADER_LENGTH + 14)
     }
     


### PR DESCRIPTION
Fixes an issue where if a MeatNetNode repeated a feature flags response from a wifi device before its own flags had been set, then it would apply the feature flags of the repeated response to itself instead of the original wifi device. 