### PR TITLE
Fix for bug where repeater nodes wouldn't repeat alarm status requests

### DIFF
--- a/Sources/CombustionBLE/ConnectionManager.swift
+++ b/Sources/CombustionBLE/ConnectionManager.swift
@@ -117,10 +117,10 @@ class ConnectionManager {
         
         lastStatusUpdate[identifier] = Date()
         
-        // Track that data was recieved for gauge on node
+        // Track that data was recieved for device on node
         node?.dataReceivedFromDevice(device)
         
-        // if receiving status from meatnet and DFU disabled, then disconnect from gauge
+        // if receiving status from meatnet and DFU disabled, then disconnect from device
         if !directConnection && meatNetEnabled && !dfuModeEnabled {
             
             if let device = getDeviceWithIdentifier(identifier),

--- a/Sources/CombustionBLE/DeviceManager.swift
+++ b/Sources/CombustionBLE/DeviceManager.swift
@@ -228,18 +228,18 @@ open class DeviceManager : DeviceManagerProtocol, ObservableObject {
     }
     
     private func getNodesConnectedToDevice(identifier: String) -> [MeatNetNode] {
-        var nodesWithProbe: [MeatNetNode] = []
+        var nodesWithDevice: [MeatNetNode] = []
         
         let meatnetNodes = getMeatnetNodes()
         
         for node in meatnetNodes {
             // Check Nodes to which we are connected to see if they have a route to the Device
             if node.connectionState == .connected, node.hasConnectionToDevice(identifier) {
-                nodesWithProbe.append(node)
+                nodesWithDevice.append(node)
             }
         }
         
-        return nodesWithProbe
+        return nodesWithDevice
     }
     
     private func shouldSendMessageDirectlyTo(probe: Probe) -> Bool {
@@ -607,7 +607,6 @@ open class DeviceManager : DeviceManagerProtocol, ObservableObject {
             completionHandler(false)
             return
         }
-        
        
         sendNodeRequestWithSuccessHandler(device, request: request, completionHandler: completionHandler)
     }
@@ -661,14 +660,17 @@ open class DeviceManager : DeviceManagerProtocol, ObservableObject {
     private func sendNodeRequestWithSuccessHandler(_ device: MeatNetNode,
                                    request: NodeRequest,
                                    completionHandler: @escaping MessageHandlers.SuccessCompletionHandler) {
-        // Send message to all nodes that have a route to the device
-        let nodesConnectedToDevice = getNodesConnectedToDevice(identifier: device.uniqueIdentifier)
-        
-        // Store completion handler
         messageHandlers.addNodeSuccessCompletionHandler(request: request, completionHandler: completionHandler)
         
-        // Send request to device
-        BleManager.shared.sendRequestToNodes(nodesConnectedToDevice, request: request)
+        if shouldSendMessageDirectlyTo(device: device) {
+            // Send request to device
+            BleManager.shared.sendRequestToNodes([device], request: request)
+        }
+        else {
+            // Send message to all nodes that have a route to the device
+            let nodesConnectedToDevice = getNodesConnectedToDevice(identifier: device.uniqueIdentifier)
+            BleManager.shared.sendRequestToNodes(nodesConnectedToDevice, request: request)
+        }
     }
 }
 
@@ -896,9 +898,9 @@ extension DeviceManager : BleManagerDelegate {
                 meatNetNode.accessory = gauge
                 
                 addAccessory(accessory: gauge)
-                
-                connectionManager.receivedDeviceAdvertising(meatNetNode, from: meatNetNode)
             }
+            
+            connectionManager.receivedDeviceAdvertising(meatNetNode)
         case .unknown, .charger, .display:
             print("Found device with unknown type")
         }

--- a/Sources/CombustionBLE/Devices/MeatNetNode.swift
+++ b/Sources/CombustionBLE/Devices/MeatNetNode.swift
@@ -144,7 +144,7 @@ public class MeatNetNode: Device {
         for deviceSerial in devices.keys {
             if let lastUpdateTime = lastTimeDataRecieved[deviceSerial] {
                 // If not data has been received from device for timeout length, then remove from list
-                if(Date().timeIntervalSince(lastUpdateTime) > Constants.DEVICE_REMOVE_CONNECTION_TIMEOUT) {
+                if Date().timeIntervalSince(lastUpdateTime) > Constants.DEVICE_REMOVE_CONNECTION_TIMEOUT {
                     removeConnectionToDevice(deviceSerial)
                 }
             }

--- a/Sources/CombustionBLE/UART/MeatNet/SetNodeHighLowAlarm.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/SetNodeHighLowAlarm.swift
@@ -26,21 +26,20 @@ import Foundation
 
 class SetNodeHighLowAlarmRequest: NodeRequest {
     
+    class Constants {
+        static let NODE_SERIAL_NUM_LENGTH = 10
+    }
+    
     init?(serialNumber: String, status: HighLowAlarmStatus) {
-        var serialNumberBytes = serialNumber
         
-        var payload = Data()
+        var payload = Data(capacity: Constants.NODE_SERIAL_NUM_LENGTH + 4)
         
-        guard let serialNumberData = serialNumber.data(using: .utf8) else {
-            return nil
-        }
+        var serialBytes = Array(serialNumber.utf8.prefix(Constants.NODE_SERIAL_NUM_LENGTH))
+        serialBytes += Array(repeating: 0, count: Constants.NODE_SERIAL_NUM_LENGTH - serialBytes.count)
         
-        payload.append(serialNumberData)
+        payload.append(contentsOf: serialBytes)
         
-        let highLowData = status.toRawData()
-        var rawHighLowData = highLowData
-        
-        payload.append(Data(bytes: &rawHighLowData, count: MemoryLayout.size(ofValue: rawHighLowData)))
+        payload.append(contentsOf: status.toRawData())
         
         super.init(outgoingPayload: payload, type: .setHighLowAlarm)
     }


### PR DESCRIPTION
Payload size was incorrect for sending via repeater nodes. Also fixes an issue where gauge may not reconnect once a repeater device goes offline