### PR TITLE
[PRO-132] Add high radio power bit to ThermometerPreferences

### DIFF
--- a/Sources/CombustionBLE/BleData/ThermometerPreferences.swift
+++ b/Sources/CombustionBLE/BleData/ThermometerPreferences.swift
@@ -28,28 +28,31 @@ public enum ProbePowerMode: UInt8, CaseIterable, Codable {
 }
 
 public struct ThermometerPreferences {
-    
+
     public let powerMode: ProbePowerMode
-    
-    public init(powerMode: ProbePowerMode) {
+    public let highRadioPower: Bool
+
+    public init(powerMode: ProbePowerMode, highRadioPower: Bool = false) {
         self.powerMode = powerMode
+        self.highRadioPower = highRadioPower
     }
 }
 
 extension ThermometerPreferences {
-    
+
     private enum Constants {
         static let POWER_MODE_MASK: UInt8 = 0x3
     }
-    
+
     static func fromByte(_ byte: UInt8) -> ThermometerPreferences {
         let rawMode = byte & (Constants.POWER_MODE_MASK)
         let mode = ProbePowerMode(rawValue: rawMode) ?? .normal
-        
-        return ThermometerPreferences(powerMode: mode)
+        let highRadioPower = (byte >> 2) & 0x1 != 0
+
+        return ThermometerPreferences(powerMode: mode, highRadioPower: highRadioPower)
     }
-    
+
     static func defaultValues() -> ThermometerPreferences {
-        return ThermometerPreferences(powerMode: .normal)
+        return ThermometerPreferences(powerMode: .normal, highRadioPower: false)
     }
 }

--- a/Sources/CombustionBLE/Devices/Device.swift
+++ b/Sources/CombustionBLE/Devices/Device.swift
@@ -78,6 +78,9 @@ open class Device : ObservableObject {
         }
     }
     
+    /// Whether device is transmitting at high radio power (+8 dBm)
+    @Published public internal(set) var highRadioPower: Bool = false
+
     /// Within Proximity Identification range
     @Published public internal(set) var withinProximityRange: Bool = false
     
@@ -202,13 +205,17 @@ extension Device {
     private enum Constants {
         /// Go stale after this many seconds of no Bluetooth activity
         static let STALE_TIMEOUT = 15.0
-        
+
         /// Minimum possible value for RSSI
         static internal let MIN_RSSI = -128
-        
-        // RSSI limits for proximity check
+
+        // RSSI limits for proximity check (normal power: +0 dBm)
         static let PROXIMITY_RSSI_MAX: Float = -48.0
         static let PROXIMITY_RSSI_MIN: Float = -55.0
+
+        // RSSI limits for proximity check (high power: +8 dBm)
+        static let PROXIMITY_RSSI_MAX_HIGH_POWER: Float = -40.0
+        static let PROXIMITY_RSSI_MIN_HIGH_POWER: Float = -47.0
     }
     
     /// Attempt to connect to the device.
@@ -246,7 +253,7 @@ extension Device {
         if(rssi > 0) {
             return
         }
-        
+
         if(rssi == Constants.MIN_RSSI) {
             // Reset values if RSSI is set to MIN
             rssiEWMA.reset()
@@ -255,12 +262,16 @@ extension Device {
         else {
             // Update RSSI EWMA
             rssiEWMA.put(value: Float(rssi))
-            
+
+            // Select thresholds based on radio power level
+            let rssiMax = highRadioPower ? Constants.PROXIMITY_RSSI_MAX_HIGH_POWER : Constants.PROXIMITY_RSSI_MAX
+            let rssiMin = highRadioPower ? Constants.PROXIMITY_RSSI_MIN_HIGH_POWER : Constants.PROXIMITY_RSSI_MIN
+
             // Check RSSI proximity
-            if(withinProximityRange && rssiEWMA.get() < Constants.PROXIMITY_RSSI_MIN) {
+            if(withinProximityRange && rssiEWMA.get() < rssiMin) {
                 withinProximityRange = false
             }
-            else if(!withinProximityRange && rssiEWMA.get() > Constants.PROXIMITY_RSSI_MAX) {
+            else if(!withinProximityRange && rssiEWMA.get() > rssiMax) {
                 withinProximityRange = true
             }
         }

--- a/Sources/CombustionBLE/Devices/Probe.swift
+++ b/Sources/CombustionBLE/Devices/Probe.swift
@@ -387,15 +387,18 @@ extension Probe {
             }
         }
 
+        // Update high radio power flag from thermometer preferences
+        highRadioPower = deviceStatus.thermometerPreferences.highRadioPower
+
         // Update most recent status notification time
         lastStatusNotificationTime = Date()
-        
+
         // Update whether status notifications are stale
         updateStatusNotificationsStale()
-        
+
         // Update time of most recent update of any type
         setLastUpdateTime()
-        
+
         // Publish most recent status
         mostRecentStatus = deviceStatus
     }


### PR DESCRIPTION
## Summary
- Adds `highRadioPower: Bool` property to `ThermometerPreferences`, parsed from bit 2 of the preferences byte
- Adds `highRadioPower` property to `Device` base class, updated from `ProbeStatus` in `Probe.updateProbeStatus()`
- Adds high-power RSSI proximity thresholds (+8 dB shift: -40/-47 vs -48/-55) to `Device.handleRSSIUpdate()`, selected based on `highRadioPower` flag

## Context
Corresponds to firmware PRO-132 which adds a high radio power status bit (bit 2) to the ThermometerPreferences BLE advertising byte. When a probe is transmitting at +8 dBm instead of +0 dBm, RSSI values are ~8 dB higher, so proximity thresholds need adjustment.

## Test plan
- [ ] Build Swift package successfully
- [ ] Connect to V2 probe with high power enabled — verify `highRadioPower` parses as `true`
- [ ] Connect to V1 probe — verify `highRadioPower` defaults to `false`
- [ ] Verify proximity detection works correctly for both normal and high-power devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)