### PR TITLE
fix: Move Read Engine Logs off the Set Gauge ID message code

### DIFF
--- a/Sources/CombustionBLE/UART/MeatNet/NodeMessageType.swift
+++ b/Sources/CombustionBLE/UART/MeatNet/NodeMessageType.swift
@@ -116,7 +116,8 @@ extension NodeMessageType {
         case .resetFoodSafe: 0x08
         case .setPowerMode: 0x09
         case .gaugeLog: 0x62
-        case .engineLog: 0x63
+        // 0x63 is SET_GAUGE_ID; the Engine block (0x70-0x72) is boxed in by linking commands.
+        case .engineLog: 0x64
         case .getFeatureFlags: 0x30
         case .connected: 0x40
         case .disconnected: 0x41


### PR DESCRIPTION
`.engineLog` mapped to `0x63`, which firmware already ships as `SET_GAUGE_ID`. A Node receiving `0x63` would parse an engine-log request as a gauge-ID write.

iOS moves rather than firmware: `SET_GAUGE_ID` is implemented across all five firmware repos via `combustion-fw-shared`, while `.engineLog` had no firmware handler and no Android counterpart — this enum entry was its only definition anywhere.

`0x64` rather than a `0x7x` code: the Engine block `0x70`-`0x72` is boxed in by the linking commands at `0x73`-`0x7B`, and `0x7C`-`0x7F` are the last four codes under the `0x80` response flag.

One line — `create(rawValue:)` reverse-maps through `allCases`, so decode follows automatically.

Note: Read Engine Logs is still absent from `engine_ble_specification.rst`, which is what allowed the collision. Worth documenting when the firmware side lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJxaT3dQsbvzPzifEvJZF5
